### PR TITLE
Adjust and export interfaces

### DIFF
--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -5,13 +5,13 @@ import { Label } from "@inubekit/label";
 import { Icon } from "@inubekit/icon";
 
 import { StyledLabel, StyledInput, StyledSpan, StyledIcon } from "./styles";
-import { Size } from "./props";
+import { IToggleSize } from "./props";
 
 interface IToggle {
   id: string;
   name?: string;
   value?: string;
-  size?: Size;
+  size?: IToggleSize;
   checked?: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   label: string;

--- a/src/Toggle/props.ts
+++ b/src/Toggle/props.ts
@@ -1,5 +1,5 @@
-export const sizes = ["small", "large"] as const;
-export type Size = (typeof sizes)[number];
+const sizes = ["small", "large"] as const;
+type IToggleSize = (typeof sizes)[number];
 
 const parameters = {
   docs: {
@@ -81,3 +81,4 @@ const props = {
 };
 
 export { props, parameters };
+export type { IToggleSize };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
 export { Toggle } from "./Toggle";
+export type { IToggle } from "./Toggle";
+export type { IToggleSize } from "./Toggle/props";


### PR DESCRIPTION
The names of the interfaces used by the `<Toggle />` component were refactored, as well as how they are exported.