### PR TITLE
Enhance `<Toggle/>` Component to Support Custom Content with children Prop

### DIFF
--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -3,46 +3,42 @@ import { inube } from "@inubekit/foundations";
 import { Stack } from "@inubekit/stack";
 import { Label } from "@inubekit/label";
 import { IIconAppearance, Icon } from "@inubekit/icon";
-
 import { StyledLabel, StyledInput, StyledSpan, StyledIcon } from "./styles";
 import { IToggleSize } from "./props";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
 
 interface IToggle {
-  id: string;
+  id?: string;
   name?: string;
   value?: string;
   size?: IToggleSize;
   checked?: boolean;
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  label: string;
-  margin: string;
-  padding: string;
+  children?: React.ReactNode;
+  margin?: string;
+  padding?: string;
   disabled?: boolean;
 }
 
 const Toggle = (props: IToggle) => {
   const {
     disabled = false,
-    id,
+    id = "toggle",
     name,
     value,
     size = "small",
     checked = false,
     onChange,
-    label,
+    children,
     margin = "0px",
     padding = "0px",
   } = props;
-
   const theme: typeof inube = useContext(ThemeContext);
   const onIconAppearance = (theme?.toggle?.on?.icon?.appereance ||
     inube.toggle.on.icon.appereance) as IIconAppearance;
-
   const offIconAppearance = (theme?.toggle?.off?.icon?.appereance ||
     inube.toggle.off.icon.appereance) as IIconAppearance;
-
   const interceptChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     try {
       onChange && onChange(e);
@@ -60,7 +56,7 @@ const Toggle = (props: IToggle) => {
       direction="row"
       justifyContent="flex-start"
       alignItems="center"
-      gap={label ? "10px" : "0px"}
+      gap={children ? "10px" : "0px"}
       margin={margin}
       padding={padding}
     >
@@ -86,14 +82,13 @@ const Toggle = (props: IToggle) => {
           </StyledIcon>
         </StyledSpan>
       </StyledLabel>
-      {label && (
+      {children && (
         <Label htmlFor={id} disabled={disabled}>
-          {label}
+          {children}
         </Label>
       )}
     </Stack>
   );
 };
-
 export { Toggle };
 export type { IToggle };

--- a/src/Toggle/props.ts
+++ b/src/Toggle/props.ts
@@ -5,78 +5,82 @@ const parameters = {
   docs: {
     description: {
       component:
-        "A switch is used to view or switch between enabled or disabled states.",
+        "A toggle switch used to change between enabled or disabled states.",
     },
   },
 };
 
 const props = {
-  id: {
-    options: ["id"],
-    control: { type: "select" },
+  checked: {
+    options: [true, false],
+    control: { type: "boolean" },
     description:
-      "this element can have a label on it, so this id allows us to connect the label with the switch",
+      "Defines whether the toggle is in the checked (enabled) or unchecked (disabled) state.",
+    table: {
+      defaultValue: { summary: false },
+    },
+  },
+  children: {
+    description:
+      "Text or elements to be displayed alongside the toggle switch.",
   },
   disabled: {
     options: [true, false],
     control: { type: "boolean" },
     description:
-      "if the switch is disabled or not. This prevents any interaction.",
+      "Disables the toggle switch when set to true, preventing user interaction.",
     table: {
       defaultValue: { summary: "false" },
     },
   },
-  checked: {
-    options: [true, false],
-    control: { type: "boolean" },
-    description: "",
+  id: {
+    options: ["id"],
+    control: { type: "select" },
+    description:
+      "The unique identifier for the toggle switch. It allows the toggle to be connected to a label.",
+  },
+  margin: {
+    type: { name: "string", required: false },
+    description:
+      "Sets the outer margin of the toggle in px or global spacing values. Accepts spacing tokens.",
     table: {
-      defaultValue: { summary: false },
+      defaultValue: { summary: "0px" },
     },
   },
   name: {
     options: ["name"],
     control: { type: "select" },
     description:
-      "descriptive name for value property to be submitted in a form",
-  },
-  value: {
-    options: ["switchTest1", "switchTest2", "switchTest3", "switchTest4"],
-    control: { type: "select" },
-    description: "value to be submitted in a form",
+      "The name of the toggle, used when submitting the value as part of a form.",
   },
   onChange: {
     options: ["logState"],
     control: { type: "func" },
     description:
-      "is a function that the component receives and that can be executed every time the switch state is modified",
-  },
-  size: {
-    options: sizes,
-    control: { type: "select" },
-    description: "toggle size",
-    table: {
-      defaultValue: { summary: "small" },
-    },
-  },
-  label: {
-    description: "component text content",
-  },
-  margin: {
-    type: { name: "string", required: false },
-    description:
-      "Sets the margin in px or global values for all four sides of the component. Accepted values are the spacing tokens",
-    table: {
-      defaultValue: { summary: "0px" },
-    },
+      "Function that is triggered whenever the toggle's state is modified.",
   },
   padding: {
     type: { name: "string", required: false },
     description:
-      "Sets the padding in px p global values for all four sides of the component. Accepted values are the spacing tokens",
+      "Sets the inner padding of the toggle in px or global spacing values. Accepts spacing tokens.",
     table: {
       defaultValue: { summary: "0px" },
     },
+  },
+  size: {
+    options: sizes,
+    control: { type: "select" },
+    description:
+      "Defines the size of the toggle switch. Options are 'small' or 'large'.",
+    table: {
+      defaultValue: { summary: "small" },
+    },
+  },
+  value: {
+    options: ["switchTest1", "switchTest2", "switchTest3", "switchTest4"],
+    control: { type: "select" },
+    description:
+      "The value to be submitted in a form when the toggle is checked.",
   },
 };
 

--- a/src/Toggle/stories/Toggle.stories.tsx
+++ b/src/Toggle/stories/Toggle.stories.tsx
@@ -27,7 +27,7 @@ Default.args = {
   onChange: action("checked"),
   margin: "0px",
   padding: "0px",
-  label: "",
+  children: "",
 };
 export { Default };
 export default story;

--- a/src/Toggle/styles.js
+++ b/src/Toggle/styles.js
@@ -93,8 +93,8 @@ const StyledInput = styled.input`
 
 const StyledIcon = styled.div`
   position: inherit;
-  top: calc(2px / 2);
-  padding-left: 2px;
+  top: calc(-2px / 2);
+  padding-left: 4px;
   width: ${({ $size }) => ($size === "small" ? "10px" : "14px")};
   height: ${({ $size }) => ($size === "small" ? "10px" : "14px")};
   left: ${({ $size, $checked, $disabled }) => {


### PR DESCRIPTION
This pull request enhances the existing `<Toggle/>` component by adding support for greater extensibility and flexibility. In addition to the current label prop, which accepts a string, the component will now support the use of children to allow developers to provide custom content for the toggle label.