### PR TITLE
Move toggle tokens from foundations to component

### DIFF
--- a/src/Toggle/Tokens/tokens.ts
+++ b/src/Toggle/Tokens/tokens.ts
@@ -1,0 +1,58 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  on: {
+    background: {
+      color: {
+        regular: inube.palette.green.G400,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.green.G300,
+      },
+    },
+    toggleBackground: {
+      color: {
+        regular: inube.palette.neutral.N0,
+        disabled: inube.palette.neutral.N0,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    toggleBorder: {
+      color: {
+        regular: inube.palette.neutralAlpha.N0A,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutralAlpha.N0A,
+      },
+    },
+    icon: {
+      appereance: "light",
+    },
+  },
+  off: {
+    background: {
+      color: {
+        regular: inube.palette.neutral.N20,
+        disabled: inube.palette.neutral.N20,
+        hover: inube.palette.neutral.N10,
+      },
+    },
+    toggleBackground: {
+      color: {
+        regular: inube.palette.neutral.N0,
+        disabled: inube.palette.neutral.N0,
+        hover: inube.palette.neutral.N0,
+      },
+    },
+    toggleBorder: {
+      color: {
+        regular: inube.palette.neutral.N70,
+        disabled: inube.palette.neutral.N70,
+        hover: inube.palette.neutral.N70,
+      },
+    },
+    icon: {
+      appereance: "gray",
+    },
+  },
+};
+
+export { tokens };

--- a/src/Toggle/index.tsx
+++ b/src/Toggle/index.tsx
@@ -1,5 +1,4 @@
 import { MdDone, MdClose } from "react-icons/md";
-import { inube } from "@inubekit/foundations";
 import { Stack } from "@inubekit/stack";
 import { Label } from "@inubekit/label";
 import { IIconAppearance, Icon } from "@inubekit/icon";
@@ -12,6 +11,7 @@ import {
 import { IToggleSize } from "./props";
 import { useContext } from "react";
 import { ThemeContext } from "styled-components";
+import { tokens } from "./Tokens/tokens";
 
 interface IToggle {
   id?: string;
@@ -40,11 +40,11 @@ const Toggle = (props: IToggle) => {
     padding = "0px",
   } = props;
 
-  const theme: typeof inube = useContext(ThemeContext);
+  const theme = useContext(ThemeContext) as { toggle: typeof tokens };
   const onIconAppearance = (theme?.toggle?.on?.icon?.appereance ||
-    inube.toggle.on.icon.appereance) as IIconAppearance;
+    tokens.on.icon.appereance) as IIconAppearance;
   const offIconAppearance = (theme?.toggle?.off?.icon?.appereance ||
-    inube.toggle.off.icon.appereance) as IIconAppearance;
+    tokens.off.icon.appereance) as IIconAppearance;
 
   const interceptChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     try {

--- a/src/Toggle/stories/Toggle.stories.tsx
+++ b/src/Toggle/stories/Toggle.stories.tsx
@@ -17,7 +17,7 @@ const story = {
 const Default = (args: IToggle) => <ToggleController {...args} />;
 Default.args = {
   id: "id",
-  disabled: true,
+  disabled: false,
   name: "name",
   value: "value",
   checked: true,

--- a/src/Toggle/styles.js
+++ b/src/Toggle/styles.js
@@ -1,6 +1,5 @@
 import styled from "styled-components";
-
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 function translateX({ $checked, $size }) {
   const margin = 2;
@@ -40,7 +39,7 @@ const StyledToggle = styled.div`
     height: ${({ $size }) => ($size === "small" ? "12px" : "16px")};
     background-color: ${({ theme }) =>
       theme?.toggle?.on?.toggleBackground?.color?.regular ||
-      inube.toggle.on.toggleBackground.color.regular};
+      tokens.on.toggleBackground.color.regular};
     border-width: 1px;
     border-style: solid;
     border-color: ${({ $checked, $disabled, theme }) => {
@@ -48,24 +47,24 @@ const StyledToggle = styled.div`
         if ($disabled) {
           return (
             theme?.toggle?.on?.toggleBorder?.color?.disabled ||
-            inube.toggle.on.toggleBorder.color.disabled
+            tokens.on.toggleBorder.color.disabled
           );
         } else {
           return (
             theme?.toggle?.on?.toggleBorder?.color?.regular ||
-            inube.toggle.on.toggleBorder.color.regular
+            tokens.on.toggleBorder.color.regular
           );
         }
       } else {
         if ($disabled) {
           return (
             theme?.toggle?.off?.toggleBorder?.color?.disabled ||
-            inube.toggle.off.toggleBorder.color.disabled
+            tokens.off.toggleBorder.color.disabled
           );
         } else {
           return (
             theme?.toggle?.off?.toggleBorder?.color?.regular ||
-            inube.toggle.off.toggleBorder.color.regular
+            tokens.off.toggleBorder.color.regular
           );
         }
       }
@@ -86,24 +85,24 @@ const StyledContainer = styled.label`
       if ($disabled) {
         return (
           theme?.toggle?.on?.background?.color?.disabled ||
-          inube.toggle.on.background.color.disabled
+          tokens.on.background.color.disabled
         );
       } else {
         return (
           theme?.toggle?.on?.background?.color?.regular ||
-          inube.toggle.on.background.color.regular
+          tokens.on.background.color.regular
         );
       }
     } else {
       if ($disabled) {
         return (
           theme?.toggle?.off?.background?.color?.disabled ||
-          inube.toggle.off.background.color.disabled
+          tokens.off.background.color.disabled
         );
       } else {
         return (
           theme?.toggle?.off?.background?.color?.regular ||
-          inube.toggle.off.background.color.regular
+          tokens.off.background.color.regular
         );
       }
     }
@@ -115,24 +114,24 @@ const StyledContainer = styled.label`
         if ($disabled) {
           return (
             theme?.toggle?.on?.background?.color?.disabled ||
-            inube.toggle.on.background.color.disabled
+            tokens.on.background.color.disabled
           );
         } else {
           return (
             theme?.toggle?.on?.background?.color?.hover ||
-            inube.toggle.on.background.color.hover
+            tokens.on.background.color.hover
           );
         }
       } else {
         if ($disabled) {
           return (
             theme?.toggle?.off?.background?.color?.disabled ||
-            inube.toggle.off.background.color.disabled
+            tokens.off.background.color.disabled
           );
         } else {
           return (
             theme?.toggle?.off?.background?.color?.hover ||
-            inube.toggle.off.background.color.hover
+            tokens.off.background.color.hover
           );
         }
       }


### PR DESCRIPTION
This PR relocates the toggle tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring components reference the correct token paths. This refactor improves the organization, maintainability, and clarity of the codebase.